### PR TITLE
geo_plots.py: fix variables not being defined if varname is None.

### DIFF
--- a/post_gnome/post_gnome/plotting/geo_plots.py
+++ b/post_gnome/post_gnome/plotting/geo_plots.py
@@ -222,8 +222,9 @@ def plot_particles(ax,filename,t,depth=0,varname=None,color='k',marker='.',marke
     times = particles.times
     dt = [np.abs(((output_t - t).total_seconds())/3600) for output_t in times]
     tidx = dt.index(min(dt))
+    variables = ['latitude', 'longitude', 'status_codes', 'depth']
     if varname is not None:
-        variables = ['latitude','longitude','status_codes','depth'] + [varname]
+        variables += [varname]
     try:
         TheData = particles.get_timestep(tidx,variables=variables)
     except: #GUI GNOME < 1.3.10


### PR DESCRIPTION
I tried to plot the NetCDF file produced by PyGnomes "script_boston" test script. However, I ran into an issue where `variables` was not defined because `varname` is not passed in the `plot_particles_at_time.py` script. I'm not sure if I may have missed something in my attempt to plot it, as the `WA_particles.nc` file plotted fine without modifying `geo_plots.py`. 

It seems that the `script_boston` script generates a new version of the NC file where instead of `status`, it is called `status_codes` and attempts the `try` statement whereas with the `WA_particles.nc` file it goes directly to the `except` lines. Not sure if there's another difference, but after declaring `variables` outside the `if` and then appending `varname` if it was defined, I managed to plot that NetCDF file with the particle plotting script.

I'm opening this Pull Request in case this was an unintended behavior when working with newer PyGnome files.

If I missed something, please let me know and disregard this PR.